### PR TITLE
Support for unescaped path information for the banner image. 

### DIFF
--- a/inst/rmarkdown/templates/ds_pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ds_pdf/skeleton/skeleton.Rmd
@@ -22,9 +22,15 @@ organization: "Data Science Core"
 # template string is used in the output block. Or name your own
 # image file. Note the width option allows the image to be stretched,
 # which may not be your intent.
-banner: "`r dsreportr::banner()`"
+banner: true
 banner_width: 6.5in
 
+# header-includes is a custom section for including extra latex. Due
+# to filename issues, we define the report banner here, but other
+# includes can be added as well.
+header-includes:
+  - "\\newcommand{\\dsreportrbanner}{`r dsreportr::banner()`}"
+  
 # Output specific options. Note that this skeleton only really applies
 # to a specific template.
 output:

--- a/inst/rmarkdown/templates/ds_pdf/templates/ds_pdf.tex
+++ b/inst/rmarkdown/templates/ds_pdf/templates/ds_pdf.tex
@@ -548,7 +548,9 @@ $endif$
 
 % Set the banner in the title field.
 $if(banner)$
-\title{\includegraphics[width=$if(banner_width)$ $banner_width$ $else$ 6.5in $endif$]{$banner$}}
+\pretitle{\begin{center}
+  \includegraphics[width=$if(banner_width)$ $banner_width$ $else$ 6.5in $endif$]{\dsreportrbanner}}
+\posttitle{\end{center}}
 $endif$
 
 % Author field is the report header table. The titling package provides


### PR DESCRIPTION
Implemented as a macro passed through from Rmd header-includes through latex. 
Fixes #1 